### PR TITLE
Set some Progression items to ignore balancing and set Birthday Cake to filler when no Brain Tank goal

### DIFF
--- a/worlds/psychonauts/Items.py
+++ b/worlds/psychonauts/Items.py
@@ -224,3 +224,13 @@ for item_name in PROGRESSION_SET:
         BASE_ITEM_CLASSIFICATIONS[item_name] = ItemClassification.progression
 for item_name in USEFUL_SET:
     BASE_ITEM_CLASSIFICATIONS[item_name] = ItemClassification.useful
+
+# Items where only the first copy is progression balanced.
+# Only one of each PSI Power is progression balanced because there are no locations that require an
+# upgraded PSI Power to access.
+# Only the first Candle is progression balanced because the second candle is only required to access a single
+# location.
+SKIP_BALANCING_FOR_DUPLICATES: Set[str] = {
+    *PSI_POWERS,
+    ItemName.Candle,
+}

--- a/worlds/psychonauts/Items.py
+++ b/worlds/psychonauts/Items.py
@@ -158,6 +158,17 @@ PROGRESSION_SET: Set[str] = {
     *PSI_POWERS,
 }
 
+# Items in the PROGRESSION_SET that should be skipped during progression balancing.
+SKIP_BALANCING_SET: Set[str] = {
+    ItemName.HedgeTrimmers,  # Required to access 3 locations
+    ItemName.RollingPin,  # Required to access 1 location
+    ItemName.FredsLetter,  # Required to access 4 locations
+    ItemName.PricelessCoin,  # Required to access 3 locations
+    ItemName.Musket,  # Required to access 2 locations
+    ItemName.Confusion,  # Required to access 2 locations
+    ItemName.Cake,  # Only required for the Brain Tank goal
+}
+
 USEFUL_SET: Set[str] = {
     ItemName.Vault,
     ItemName.ChallengeMarker,

--- a/worlds/psychonauts/Items.py
+++ b/worlds/psychonauts/Items.py
@@ -1,5 +1,7 @@
 from typing import Dict, Set
 
+from BaseClasses import ItemClassification
+
 from .Names import ItemName
 from .PsychoRandoItems import PSYCHORANDO_ITEM_TABLE
 
@@ -212,3 +214,13 @@ ITEM_COUNT: Dict[str, int] = {
     ItemName.AHSmall: 30,
     ItemName.AHLarge: 5,
 }
+
+# Classification for each item. Items not in the Dict are assumed to be Filler.
+BASE_ITEM_CLASSIFICATIONS: Dict[str, ItemClassification] = {}
+for item_name in PROGRESSION_SET:
+    if item_name in SKIP_BALANCING_SET:
+        BASE_ITEM_CLASSIFICATIONS[item_name] = ItemClassification.progression_skip_balancing
+    else:
+        BASE_ITEM_CLASSIFICATIONS[item_name] = ItemClassification.progression
+for item_name in USEFUL_SET:
+    BASE_ITEM_CLASSIFICATIONS[item_name] = ItemClassification.useful

--- a/worlds/psychonauts/Rules.py
+++ b/worlds/psychonauts/Rules.py
@@ -150,8 +150,6 @@ class PsyRules:
 
             RegionName.ASUPTele: self.has_telekinesis,
 
-            RegionName.ASLBBoss: lambda state: self.has_cake(state) and self.has_pyrokinesis(state),
-
             RegionName.BBA1: self.has_coach_mind,
 
             RegionName.BBA2Duster: self.has_cobweb_duster,

--- a/worlds/psychonauts/__init__.py
+++ b/worlds/psychonauts/__init__.py
@@ -101,6 +101,10 @@ class PSYWorld(World):
             for name in BRAIN_JARS:
                 item_classifications[name] = ItemClassification.progression_skip_balancing
 
+        # Set Birthday Cake to Filler, when the Brain Tank goal is not enabled.
+        if goal == Goal.option_brainhunt:
+            item_classifications[ItemName.Cake] = ItemClassification.filler
+
     def create_item(self, name: str) -> Item:
         """
         Returns created PSYItem

--- a/worlds/psychonauts/__init__.py
+++ b/worlds/psychonauts/__init__.py
@@ -17,7 +17,8 @@ from .Items import (
     USEFUL_SET,
     ITEM_GROUPS,
     ITEM_COUNT,
-    AP_ITEM_OFFSET
+    AP_ITEM_OFFSET,
+    SKIP_BALANCING_SET,
 )
 from .Locations import ALL_LOCATIONS, AP_LOCATION_OFFSET, DEEP_ARROWHEAD_LOCATIONS, MENTAL_COBWEB_LOCATIONS
 from .Names import ItemName, LocationName
@@ -100,6 +101,9 @@ class PSYWorld(World):
             item_classification = ItemClassification.useful
         else:
             item_classification = ItemClassification.filler
+
+        if item_classification == ItemClassification.progression and name in SKIP_BALANCING_SET:
+            item_classification = ItemClassification.progression_skip_balancing
 
         created_item = PSYItem(name, item_classification, self.item_name_to_id[name], self.player)
 


### PR DESCRIPTION
Hedge Trimmers, Rolling Pin, Fred's Letter, Priceless Coin, Musket, Progressive Confusion and Birthday Cake and Brains each are only required for very few or no locations, so they have been set to be ignoring during progression balancing.

Duplicates of PSI Powers, similarly, are not required for any locations, and the second Candle is only required for a single location, so duplicates of these items have also been set to be ignored during progression balancing.

Additionally, the Birthday Cake is now classified as filler when the Brain Tank goal is not enabled. Because it is filler when this is the case, the Brain Hunt-only tests would fail because the Brain Tank Boss region (`Oleander Boss Event (ASLB)`) still had logic checking for having the Birthday Cake. To fix this, the logic for the Brain Tank Boss region has been removed because the Brain Tank Boss logic is already set on the Brain Tank Boss location when the Brain Tank goal is enabled. An alternative to this could be to not create the goal regions/locations for disabled goals in the first place.

To prevent the `create_item()` method getting even longer with these changes, the base `ItemClassification` of each item is now set into the `BASE_ITEM_CLASSIFICATIONS` dict in `Items.py`. This dict is then copied during `generate_early()` and the copy is modified for any items whose `ItemClassification` must change because of the options being used to generate. `create_item()` then looks up the `ItemClassification` for each item it creates, defaulting to `ItemClassification.filler` if there is no `ItemClassification` specified.