### PR TITLE
Tests: Fix base class `.options` being modified

### DIFF
--- a/worlds/psychonauts/test/test_goal_options.py
+++ b/worlds/psychonauts/test/test_goal_options.py
@@ -41,7 +41,12 @@ class PsychonautsMinimalVictoryTestBase(PsychonautsTestBase):
     @classmethod
     def setUpClass(cls):
         # For minimal tests, no starting items are allowed.
-        cls.options.update({
+        options = cls.options
+        # Ensure `.options` is overridden, so that the base class' `.options` does not get modified.
+        if options is PsychonautsMinimalVictoryTestBase.options:
+            options = {}
+            cls.options = options
+        options.update({
             "RandomStartingMinds": 0,
             "StartingLevitation": False,
             "StartingMentalMagnet": False,


### PR DESCRIPTION
The Stardew Valley tests recently added checks that all its options belong to Stardew Valley. Because PsychonautsMinimalVictoryTestBase was mistakenly causing WorldTestBase.options to be modified, the Stardew Valley test would fail.

PsychonautsMinimalVictoryTestBase has been modified to ensure that it always overrides WorldTestBase.options in `setUpClass()` if it has not already been overridden by a subclass.
