### PR TITLE
Fix sending level change Bounce to all trackers

### DIFF
--- a/worlds/psychonauts/Client.py
+++ b/worlds/psychonauts/Client.py
@@ -408,7 +408,7 @@ async def game_watcher(ctx: PsychonautsContext):
                 current_level_name = f.read(4)
                 if ctx.current_level_name != current_level_name:
                     ctx.current_level_name = current_level_name
-                    # Send a Bounced message to all client connected to the current slot (intended for trackers only)
+                    # Send a Bounced message to all clients connected to the current slot (intended for trackers only)
                     data_to_send = {"psychonauts_level_name": current_level_name}
                     message = {
                         "cmd": "Bounce",

--- a/worlds/psychonauts/Client.py
+++ b/worlds/psychonauts/Client.py
@@ -408,12 +408,11 @@ async def game_watcher(ctx: PsychonautsContext):
                 current_level_name = f.read(4)
                 if ctx.current_level_name != current_level_name:
                     ctx.current_level_name = current_level_name
-                    # Send a Bounced message to all trackers connected to the current slot
+                    # Send a Bounced message to all client connected to the current slot (intended for trackers only)
                     data_to_send = {"psychonauts_level_name": current_level_name}
                     message = {
                         "cmd": "Bounce",
                         "slots": [ctx.slot],
-                        "tags": ["Tracker"],
                         "data": data_to_send,
                     }
                     await ctx.send_msgs([message])


### PR DESCRIPTION
The AP server sends a Bounced message, in response to a Bounce message, to all clients that match *any* of the slots/tags specified, so the client was causing the Bounce message to be sent to all clients connect to the same slot as the game client *and* to all clients connected with the tracker tag.

Removing the tracker tag from the Bounce message means that the Bounced message will now only be sent to clients connected to the same slot as the game client.